### PR TITLE
spawn working swarm with docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 tmp
 .git
 Dockerfile
+docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -5,12 +5,19 @@ chain and module config, which includes a multi token module and a voting module
 
 # Quick setup using Docker
 
-```
+```bash
 docker build -t full-node .
 docker run -p 9944:9944 full-node --alice
 ```
 
 See the Dockerfile for more details.
+
+# Quick p2p swarm simulation using docker-compose
+
+```bash
+docker-compose up --scale standard=5
+#                                  ^ number of default nodes to simulate
+```
 
 # Development setup
 
@@ -67,7 +74,8 @@ substrate --chain ./tmp/chainspec.json --alice --base-path ./tmp
 
 # Using the polkadot js UI
 
-Once the dev chain is running, natively or within docker, you can interact with it via browser.
+Once the dev chain is running, natively; within docker; or through docker-compose, you can interact
+with it via browser.
 
 Go to https://polkadot.js.org/apps/#/settings and set "remote endpoint" to your locally running node 127.0.0.1.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+# Defauls substrate ports:
+#   30333 - p2p
+#    9933 - http jsonrpc
+#    9944 - websocket jsonrpc
+
+services:
+  verifier: # verifier is also uses as the bootstrap node
+    build: .
+    command: ["--alice"]
+    ports:
+      - "30333:30333"
+
+  # you can use `docker-compose up --scale stantard=<n>` to spawn <n> standard nodes
+  # (--remove-orphans to remove)
+  standard:
+    build: .
+
+  rpc: # a node that exposes it's ws jsonrpc api*
+    build: .
+    ports:
+      - "9944:9944"


### PR DESCRIPTION
closes #17 

This pr introduces a docker-compose configuration that spawns an arbitrary number of nodes, a validator, and a ws jsonrpc bridge. The nodes don't need an explicit bootstrap config in this case because they all exist on the same lan; mdns is enough.

I recommend running `docker-compose up --scale standard=5` just for the entertainment value. It's neat to watch blocks get produced and propagated through the network.

You can interact with the generated swarm via the https://polkadot.js.org/apps gui.

The readme is updated accordingly.